### PR TITLE
Reload the slash commands with /reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,6 @@
 
 ## Suggetions:
   - [ ] Rewrite database to better data model, such as sqlx or Postgres
+
+## Misc
+  - [x] Reload command: dtomvan

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -12,6 +12,7 @@ pub mod ping;
 pub mod prefabs;
 pub mod purge;
 pub mod reaction;
+pub mod reload;
 pub mod roll;
 pub mod screenshare;
 pub mod screensharers;

--- a/src/commands/reload.rs
+++ b/src/commands/reload.rs
@@ -1,0 +1,41 @@
+use serenity::{
+    async_trait, client::Context,
+    model::interactions::application_command::{ApplicationCommandInteraction, ApplicationCommandPermissionType},
+};
+
+use crate::consts::CONFIG;
+
+pub struct Reload;
+
+#[async_trait]
+impl super::Command for Reload {
+    fn name(&self) -> String {
+        String::from("reload")
+    }
+    async fn register(&self, ctx: &Context) -> crate::Result<()> {
+        let cmd = CONFIG.guild.create_application_command(&ctx.http, |cmd| {
+            cmd.name(self.name())
+                .description("Reloads application commands.")
+                .default_permission(false)
+        }).await?;
+
+        CONFIG.guild.create_application_command_permission(&ctx.http, cmd.id, |perm| {
+            perm.create_permission(|perm| {
+                perm.kind(ApplicationCommandPermissionType::Role)
+                    .id(CONFIG.staff.0)
+            })
+        }).await?;
+
+        Ok(())
+    }
+    async fn run(
+        &self,
+        ctx: &Context,
+        command: &ApplicationCommandInteraction,
+    ) -> crate::Result<()> {
+        Ok(())
+    }
+    fn new() -> Box<Self> {
+        Box::new(Self)
+    }
+}

--- a/src/commands/reload.rs
+++ b/src/commands/reload.rs
@@ -1,6 +1,9 @@
 use serenity::{
-    async_trait, client::Context,
-    model::interactions::application_command::{ApplicationCommandInteraction, ApplicationCommandPermissionType},
+    async_trait,
+    client::Context,
+    model::interactions::application_command::{
+        ApplicationCommandInteraction, ApplicationCommandPermissionType,
+    },
 };
 
 use crate::consts::CONFIG;
@@ -13,26 +16,41 @@ impl super::Command for Reload {
         String::from("reload")
     }
     async fn register(&self, ctx: &Context) -> crate::Result<()> {
-        let cmd = CONFIG.guild.create_application_command(&ctx.http, |cmd| {
-            cmd.name(self.name())
-                .description("Reloads application commands.")
-                .default_permission(false)
-        }).await?;
-
-        CONFIG.guild.create_application_command_permission(&ctx.http, cmd.id, |perm| {
-            perm.create_permission(|perm| {
-                perm.kind(ApplicationCommandPermissionType::Role)
-                    .id(CONFIG.staff.0)
+        let cmd = CONFIG
+            .guild
+            .create_application_command(&ctx.http, |cmd| {
+                cmd.name(self.name())
+                    .description("Reloads application commands.")
+                    .default_permission(false)
             })
-        }).await?;
+            .await?;
+
+        CONFIG
+            .guild
+            .create_application_command_permission(&ctx.http, cmd.id, |perm| {
+                perm.create_permission(|perm| {
+                    perm.kind(ApplicationCommandPermissionType::Role)
+                        .id(CONFIG.staff.0)
+                })
+            })
+            .await?;
 
         Ok(())
     }
     async fn run(
         &self,
         ctx: &Context,
-        command: &ApplicationCommandInteraction,
+        _command: &ApplicationCommandInteraction,
     ) -> crate::Result<()> {
+        let commands = CONFIG
+            .guild
+            .get_application_commands(&ctx.http)
+            .await?
+            .into_iter()
+            .map(|x| x.id);
+        for id in commands {
+            CONFIG.guild.delete_application_command(&ctx.http, id).await?;
+        }
         Ok(())
     }
     fn new() -> Box<Self> {

--- a/src/commands/reload.rs
+++ b/src/commands/reload.rs
@@ -31,6 +31,7 @@ impl super::Command for Reload {
                 perm.create_permission(|perm| {
                     perm.kind(ApplicationCommandPermissionType::Role)
                         .id(CONFIG.staff.0)
+                        .permission(true)
                 })
             })
             .await?;

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -40,47 +40,49 @@ use serenity::model::id::GuildId;
 use serenity::model::user::User;
 
 use regex::Regex;
+use lazy_static::lazy_static;
 
 type Command = Box<dyn crate::commands::Command>;
 
+lazy_static! {
+    pub static ref COMMANDS: Vec<Command> = vec![
+        Council::new(),
+        Notes::new(),
+        Prefab::new(),
+        Timeout::new(),
+        Ban::new(),
+        Unban::new(),
+        ScrimBan::new(),
+        ScrimUnban::new(),
+        Roll::new(),
+        Teams::new(),
+        Purge::new(),
+        Reaction::new(),
+        DelReaction::new(),
+        ListReactions::new(),
+        Ping::new(),
+        Screenshare::new(),
+        Close::new(),
+        Freeze::new(),
+        Unfreeze::new(),
+        Ticket::new(),
+        ListBans::new(),
+        Screensharers::new(),
+        Reload::new(),
+    ];
+}
+
 pub struct Handler {
-    commands: HashMap<String, Command>,
+    commands: HashMap<String, &'static Command>,
     reactions: Arc<Mutex<HashMap<String, CustomReaction>>>,
 }
 
 impl Handler {
     pub fn new() -> Handler {
-        let commands: Vec<Command> = vec![
-            Council::new(),
-            Notes::new(),
-            Prefab::new(),
-            Timeout::new(),
-            Ban::new(),
-            Unban::new(),
-            ScrimBan::new(),
-            ScrimUnban::new(),
-            Roll::new(),
-            Teams::new(),
-            Purge::new(),
-            Reaction::new(),
-            DelReaction::new(),
-            ListReactions::new(),
-            Ping::new(),
-            Screenshare::new(),
-            Close::new(),
-            Freeze::new(),
-            Unfreeze::new(),
-            Ticket::new(),
-            ListBans::new(),
-            Screensharers::new(),
-            Reload::new(),
-        ];
-        let commands = commands
-            .into_iter()
-            .fold(HashMap::new(), |mut map, command| {
-                map.insert(command.name(), command);
-                map
-            });
+        let commands = COMMANDS.iter().fold(HashMap::new(), |mut map, command| {
+            map.insert(command.name(), command);
+            map
+        });
 
         Handler {
             commands,
@@ -354,7 +356,7 @@ async fn update(m: Arc<Mutex<HashMap<String, CustomReaction>>>) {
 
 async fn register_commands(
     ctx: &Context,
-    commands: &HashMap<String, Command>,
+    commands: &HashMap<String, &'static Command>,
 ) -> Result<(), String> {
     let mut res = Ok(());
     let guild_commands = CONFIG.guild.get_application_commands(&ctx.http).await;


### PR DESCRIPTION
What this does:
- When the bot starts up, it only registers the commands that aren't
  registered yet.
- When using /reload, remove and readd every guild command.

This is made so that the bot doesn't get ratelimited.

Closes: #39