### PR TITLE
Screenshare fixes

### DIFF
--- a/src/commands/screenshare.rs
+++ b/src/commands/screenshare.rs
@@ -189,10 +189,11 @@ impl Command for Screenshare {
 
             message.content(format!(
                 "<@&{}>
-Please explain how <@{}> is cheating and screenshots of you telling them
+<@{}> Please explain how <@{}> is cheating and screenshots of you telling them
 not to log aswell as any other info.
 ",
                 crate::consts::CONFIG.ss_support,
+                command.user.id.0,
                 in_question
             ));
 

--- a/src/commands/screenshare.rs
+++ b/src/commands/screenshare.rs
@@ -204,7 +204,7 @@ not to log aswell as any other info.
                     .title("Screenshare Request")
                     .description(
                         "- Why did you request a screenshare on this member?
-- Please provide evidence of you telling him not to log.
+- __**Please provide evidence of you telling him not to log.**__
 - Anything else?
 
 **NOTE**: If you do not get frozen within 15 minutes you may logout.

--- a/src/commands/screenshare.rs
+++ b/src/commands/screenshare.rs
@@ -185,58 +185,64 @@ impl Command for Screenshare {
                     )
                     .await?;
             }
-            let mut m = channel.send_message(&ctx.http, |m| m.content(format!(
-                "<@&{}>
+            let mut m = channel
+                .send_message(&ctx.http, |m| {
+                    m.content(format!(
+                        "<@&{}>
 <@{}> Please explain how <@{}> is cheating and screenshots of you telling them
 not to log aswell as any other info.
 ",
-                crate::consts::CONFIG.ss_support,
-                command.user.id.0,
-                in_question
-            )).embed(|embed| {
-                embed
-                    .title("Screenshare Request")
-                    .description(
-                        "- Why did you request a screenshare on this member?
+                        crate::consts::CONFIG.ss_support,
+                        command.user.id.0,
+                        in_question
+                    ))
+                    .embed(|embed| {
+                        embed
+                            .title("Screenshare Request")
+                            .description(
+                                "- Why did you request a screenshare on this member?
 - __**Please provide evidence of you telling him not to log.**__
 - Anything else?
 
 **NOTE**: If you do not get frozen within 15 minutes you may logout.
 ",
-                    )
-                    .field("Ign", name, false)
-                    .field(
-                        "Last login time",
-                        playerstats.last_login.unwrap_or_default(),
-                        false,
-                    )
-                    .field(
-                        "Last logout time",
-                        playerstats.last_logout.unwrap_or_default(),
-                        false,
-                    )
-            }).components(|components| {
-                components.create_action_row(|row| {
-                    row.create_button(|button| {
-                        button
-                            .label("Freeze")
-                            .style(ButtonStyle::Primary)
-                            .emoji(ReactionType::Custom {
-                                animated: false,
-                                id: crate::CONFIG.freeze_emoji,
-                                name: None,
-                            })
-                            .custom_id(format!("freeze:{}", in_question))
+                            )
+                            .field("Ign", name, false)
+                            .field(
+                                "Last login time",
+                                playerstats.last_login.unwrap_or_default(),
+                                false,
+                            )
+                            .field(
+                                "Last logout time",
+                                playerstats.last_logout.unwrap_or_default(),
+                                false,
+                            )
                     })
-                        .create_button(|button| {
-                            button
-                                .label("Close")
-                                .style(ButtonStyle::Danger)
-                                .emoji(ReactionType::Unicode(From::from("⛔")))
-                                .custom_id(format!("close:{}", channel.id))
+                    .components(|components| {
+                        components.create_action_row(|row| {
+                            row.create_button(|button| {
+                                button
+                                    .label("Freeze")
+                                    .style(ButtonStyle::Primary)
+                                    .emoji(ReactionType::Custom {
+                                        animated: false,
+                                        id: crate::CONFIG.freeze_emoji,
+                                        name: None,
+                                    })
+                                    .custom_id(format!("freeze:{}", in_question))
+                            })
+                            .create_button(|button| {
+                                button
+                                    .label("Close")
+                                    .style(ButtonStyle::Danger)
+                                    .emoji(ReactionType::Unicode(From::from("⛔")))
+                                    .custom_id(format!("close:{}", channel.id))
+                            })
                         })
+                    })
                 })
-            })).await?;
+                .await?;
             command
                 .create_interaction_response(&ctx.http, |resp| {
                     resp.interaction_response_data(|data| {

--- a/src/commands/unban.rs
+++ b/src/commands/unban.rs
@@ -149,10 +149,8 @@ impl UnbanType {
                 }
 
                 // If roles cannot be added, don't remove the unban from the database either
-                if result.is_ok() {
-                    db_result =
-                        crate::consts::DATABASE.remove_entry("ScheduledScrimUnbans", to_unban.id.0);
-                }
+                db_result =
+                    crate::consts::DATABASE.remove_entry("ScheduledScrimUnbans", to_unban.id.0);
             }
         }
         if result.is_ok() {

--- a/src/lib/print_embeds.rs
+++ b/src/lib/print_embeds.rs
@@ -75,7 +75,7 @@ impl Display for FormatEmbed {
 
 #[cfg(test)]
 mod tests {
-    use serenity::{builder::CreateEmbed, utils::Colour};
+    use serenity::{builder::CreateEmbed, model::Timestamp, utils::Colour};
 
     use super::*;
 
@@ -96,7 +96,7 @@ mod tests {
             .footer(|footer| footer.icon_url("https://example.com").text("Bridge Scrims"))
             .image("http://via.placeholder.com/150")
             .thumbnail("http://via.placeholder.com/150")
-            .timestamp("1 jan 1970")
+            .timestamp(Timestamp::from_unix_timestamp(0).unwrap())
             .title("A very nice embed")
             .url("http://bridgescrims.com");
 
@@ -122,8 +122,8 @@ Image: http://via.placeholder.com/150
 Thumbnail: http://via.placeholder.com/150
 > Bridge Scrims
 Icon: https://example.com
-Timestamp: 1 jan 1970
-"
+Timestamp: 1970-01-01T00:00:00.000Z
+" // yes i did just make it ugly
             )
         );
     }


### PR DESCRIPTION
This does 2 things:
 - Shows who opened the screenshare ticket
 - Prevents both the person who opened the ticket and the person being accused of cheating from interacting with the buttons. Previously, they could click the buttons which would cause the buttons to disappear, and the ticket to never close.